### PR TITLE
Add sendgrid reset password functionality

### DIFF
--- a/MechanicChecker/MechanicChecker/Helper/EmailSender.cs
+++ b/MechanicChecker/MechanicChecker/Helper/EmailSender.cs
@@ -20,5 +20,16 @@ namespace MechanicChecker.Helper
             Response response = await client.SendEmailAsync(msg);
             return response;
         }
+
+        public static async Task<Response> SendResetPasswordEmail(string resetPasswordLink, string toName, string toEmail)
+        {
+            var client = new SendGridClient(sendgridAPIKey);
+            var from = new EmailAddress("mechanicchecker@outlook.com", "Mechanic Checker");
+            var to = new EmailAddress(toEmail, toName);
+
+            var msg = MailHelper.CreateSingleTemplateEmail(from, to, "d-8a2852521a1c47578f046c1ef0ca0cf7", new { name = toName, link = resetPasswordLink });
+            var response = await client.SendEmailAsync(msg);
+            return response;
+        }
     }
 }

--- a/MechanicChecker/MechanicChecker/Models/SellerContext.cs
+++ b/MechanicChecker/MechanicChecker/Models/SellerContext.cs
@@ -81,19 +81,94 @@ namespace MechanicChecker.Models
                 isPassed = reader.Read() && (Convert.ToBoolean(reader["IsApproved"]) == false);
             }
 
-            if (isPassed.Equals(true))
+            if (isPassed)
             {
                 string stringCmd = "UPDATE Seller SET IsApproved = 1, ApprovalDate = '" + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + "' WHERE ActivationCode = '" + activationId + "';";
 
                 MySqlCommand secondCommand = new MySqlCommand(stringCmd);
                 secondCommand.Connection = myConnection;
                 secondCommand.ExecuteNonQuery(); // ExecuteNonQuery is required to update, insert and delete from the DB 
-
             }
             myConnection.Close();
 
             return isPassed;
 
+        }
+        public bool verifyUserByEmail(string email, out string sellerName)
+        {
+            bool isPassed = false;
+
+            string command = "SELECT Username, Email from Seller where Email = '" + email + "';";
+
+            // send query to database
+            MySqlConnection myConnection = GetConnection();
+            MySqlCommand myCommand = new MySqlCommand(command);
+            myCommand.Connection = myConnection;
+            myConnection.Open();
+
+            // read response
+            using (var reader = myCommand.ExecuteReader())
+            {
+                // will only run if the query returns a record
+                isPassed = reader.Read();
+                if (isPassed)
+                {
+                    sellerName = reader["Username"].ToString();
+                }
+                else
+                {
+                    sellerName = null;
+                }
+                
+            }
+
+            return isPassed;
+        }
+
+        public bool updatePassword(string password, string resetPasswordCode)
+        {
+            bool isPassed = false;
+
+            string command = "UPDATE Seller SET PasswordHash = '" + password + "' WHERE ResetPasswordCode = '" + resetPasswordCode + "';";
+
+            // send query to database
+            MySqlConnection myConnection = GetConnection();
+            MySqlCommand myCommand = new MySqlCommand(command);
+            myCommand.Connection = myConnection;
+            myConnection.Open();
+            isPassed = Convert.ToBoolean(myCommand.ExecuteNonQuery()); // only 1 row should be affected; if failed then 0 rows were affected
+
+            // remove ResetPasswordCode from DB since its not needed anymore
+            // also prevents anyone from resetting the password with the same link again
+            if (isPassed)
+            {
+                myCommand.CommandText = "UPDATE Seller SET ResetPasswordCode = " + "NULL" + " WHERE ResetPasswordCode = '" + resetPasswordCode + "';";
+                isPassed = Convert.ToBoolean(myCommand.ExecuteNonQuery()); // only 1 row should be affected; if failed then 0 rows were affected
+                myCommand.Connection.Close();
+            }
+            else
+            {
+                myCommand.Connection.Close();
+            }
+
+            return isPassed;
+        }
+
+        public bool updateResetPasswordCode(string resetPasswordCode, string sellerEmail)
+        {
+            bool isPassed = false;
+
+            string command = "UPDATE Seller SET ResetPasswordCode = '" + resetPasswordCode + "' WHERE Email = '" + sellerEmail + "';";
+
+            // send query to database
+            MySqlConnection myConnection = GetConnection();
+            MySqlCommand myCommand = new MySqlCommand(command);
+            myCommand.Connection = myConnection;
+            myConnection.Open();
+            isPassed = Convert.ToBoolean(myCommand.ExecuteNonQuery()); // only 1 row should be affected; if failed then 0 rows were affected
+            myCommand.Connection.Close();
+
+            return isPassed;
         }
 
     }

--- a/MechanicChecker/MechanicChecker/Views/Account/ResetPassword.cshtml
+++ b/MechanicChecker/MechanicChecker/Views/Account/ResetPassword.cshtml
@@ -1,0 +1,36 @@
+﻿
+
+@{
+    ViewData["Title"] = "Home Page";
+    Layout = "_Layout";
+}
+
+<link href="~/css/style.css" rel="stylesheet" />
+<br />
+<br />
+<br />
+
+<div class="signinform">
+    <h3>@TempData["ResetPassword"]</h3>
+    <div>
+        <img src="~/images/MechanicCheckerLogoSmaller.png" alt="Mechanic Checker App Logo" height="55" width="130" class="center-block">
+    </div>
+
+    <h3>Forgot Your Passowrd?</h3>
+    <h5>Enter your email</h5>
+    <div class="text-danger"></div>
+    <form action="ResetPassword" controller="Account" method="post">
+        <input type="hidden" />
+        <div class="form-group">
+            <label for="Email">Email</label>
+            <div><span class="text-danger"></span></div>
+            <input type="text" name="Email" class="form-control" required />
+        </div>
+
+        <button class="btn btn-primary" type="submit">Submit</button>
+    </form>
+</div>
+
+<br />
+<br />
+<br />

--- a/MechanicChecker/MechanicChecker/Views/Account/SignIn.cshtml
+++ b/MechanicChecker/MechanicChecker/Views/Account/SignIn.cshtml
@@ -11,7 +11,7 @@
 <br />
 
 <div class="signinform">
-    <h3>@ViewData["SignIn"]</h3>
+    <h3>@TempData["SignIn"]</h3>
     <div>
         <img src="~/images/MechanicCheckerLogoSmaller.png" alt="Mechanic Checker App Logo" height="55" width="130" class="center-block">
     </div>
@@ -32,9 +32,9 @@
         </div>
         <button class="btn btn-primary" asp-controller="LocalSeller" asp-action="Index" type="submit">Sign In</button>
     </form>
-    <h5>Reser your password? </h5>
+    <h5><a asp-controller="Account" asp-action="ResetPassword" method="post">Reset your password? </a></h5>
 </div>
 
 <br />
 <br />
-<br />>
+<br />

--- a/MechanicChecker/MechanicChecker/Views/Account/UpdatePassword.cshtml
+++ b/MechanicChecker/MechanicChecker/Views/Account/UpdatePassword.cshtml
@@ -1,0 +1,36 @@
+﻿
+
+@{
+    ViewData["Title"] = "Home Page";
+    Layout = "_Layout";
+}
+
+<link href="~/css/style.css" rel="stylesheet" />
+<br />
+<br />
+<br />
+
+<div class="signinform">
+    <h3>@ViewData["PostUpdatePassword"]</h3>
+    <div>
+        <img src="~/images/MechanicCheckerLogoSmaller.png" alt="Mechanic Checker App Logo" height="55" width="130" class="center-block">
+    </div>
+
+    <h3>Update Your Passowrd</h3>
+    <h5>Enter Your New Password</h5>
+    <div class="text-danger"></div>
+    <form action="ResetPassword" controller="Account" method="post">
+        <input type="hidden" value="@ViewBag.id" name="resetCode" />
+        <div class="form-group">
+            <label for="Password">Password</label>
+            <div><span class="text-danger"></span></div>
+            <input type="password" name="Password" class="form-control" required />
+        </div>
+
+        <button class="btn btn-primary" type="submit">Submit</button>
+    </form>
+</div>
+
+<br />
+<br />
+<br />


### PR DESCRIPTION
Closes #49 

Add sendgrid reset password functionality. A reset password code is created whenever a person requests a password reset. The reset password email sent to the user will redirect to the reset password page with the reset password code as the unique id in the url. When they reset their password the reset password code in the database becomes NULL to prevent the same link to be used again to reset the user's password.